### PR TITLE
feat: repository owner avatar url

### DIFF
--- a/contributed.go
+++ b/contributed.go
@@ -43,12 +43,8 @@ var (
 	port      string
 )
 
-// Info is returned to the user.
-type Info struct {
-	Owner     string
-	URL       string
-	AvatarURL string
-}
+// MergedPullRequestInfo contains the relevant information which is fetched from
+// the GraphQL query, this is returned to the user.
 type MergedPullRequestInfo struct {
 	RepositoryOwner string
 	PullRequestURL  string


### PR DESCRIPTION
Add in the `avatarUrl` for a repository owner, this will provide a convenient way to display an icon for the owner of the repository on the frontend of the application - when it is eventually created.

Minor cleanup for renaming the `Info` struct into `MergedPullRequestInfo` for clarity.