### PR TITLE
feat: cache invalidation http header and cli opt

### DIFF
--- a/contributed.go
+++ b/contributed.go
@@ -54,6 +54,11 @@ func main() {
 	router.GET("/user/:name", func(c *gin.Context) {
 
 		name := c.Param("name")
+		_, ok := c.Request.Header[contributed.CacheRefreshHeader]
+		if ok {
+			cache.Remove(name)
+			log.Printf("%s invalidated from cache", name)
+		}
 
 		// Some requests can take a long time. Using an LRU cache here means
 		// that the first time a request comes in, it may take awhile to sift

--- a/pkg/contributed/contributed.go
+++ b/pkg/contributed/contributed.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	// HTTP header to force cache invalidation
+	CacheRefreshHeader = "X-Contributed-Cache-Refresh"
+)
+
 var (
 
 	// The static GraphQL query which we need to use in order to fetch the relevant


### PR DESCRIPTION
Add `refresh` option for cache invalidation which sends a `X-Contributed-Cache-Refresh` HTTP header, enabling client-side invalidation.

At the moment, the data within the cache will become stale for however long the application remains running, as the cache is rather large and there are not enough requests to cause various evictions which would cause a cycling of the data contained within it.
