### PR TITLE
ci: remove api prefix from image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.owner }}/contributed-to:api-${{ steps.tag.outputs.tag }}
+          tags: ${{ env.owner }}/contributed-to:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
Initially, I thought about having the UI split and entirely separate, but as this is a small personal project, I can deal with this being a relatively janky HTML template that is rendered from the Go server.
