### PR TITLE
refactor: simplify data model to `struct`

### DIFF
--- a/cmd/contributed/contributed.go
+++ b/cmd/contributed/contributed.go
@@ -89,12 +89,12 @@ func main() {
 		for _, c := range contributions {
 			fmt.Printf("\t%+v\n", c.Owner)
 
-			for _, x := range c.Repos {
-				fmt.Printf("\t\t%s\n", x.Name)
+			for _, r := range c.Repos {
+				fmt.Printf("\t\t%s\n", r.Name)
 
 				if fullInfo {
-					for _, y := range x.PullRequests {
-						fmt.Printf("\t\t\t%s %s\n", y.Title, y.URL)
+					for _, pr := range r.PullRequests {
+						fmt.Printf("\t\t\t%s %s\n", pr.Title, pr.URL)
 					}
 				}
 			}

--- a/cmd/contributed/contributed.go
+++ b/cmd/contributed/contributed.go
@@ -47,10 +47,6 @@ func getUser(user string, refreshCache bool) ([]contributed.Contribution, error)
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusAccepted {
-		return contributions, nil
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/cmd/contributord/contributord.go
+++ b/cmd/contributord/contributord.go
@@ -105,7 +105,7 @@ func main() {
 			log.Printf("%s invalidated from cache", githubUser)
 		}
 
-		contributions, err := getContributions(githubUser,client,  cache)
+		contributions, err := getContributions(githubUser, client, cache)
 		if err != nil {
 			msg := fmt.Sprintf("unable to fetch data for %s", githubUser)
 			c.JSON(500, gin.H{

--- a/cmd/contributord/contributord.go
+++ b/cmd/contributord/contributord.go
@@ -23,12 +23,6 @@ var (
 	uiServeFile string
 )
 
-func printContributions(co []contributed.Contribution) {
-	for _, c := range co {
-		log.Printf("%+v\n", c.Owner)
-	}
-}
-
 
 func main() {
 	flag.IntVar(&cacheSize, "cache-size", 1000, "number of items available to cache")

--- a/cmd/contributord/contributord.go
+++ b/cmd/contributord/contributord.go
@@ -23,53 +23,12 @@ var (
 	uiServeFile string
 )
 
-// TODO: clean this up and use the structs here for the actual return data so we
-// don't have to do anything special for returning the information and manipulating it.
-// This is fine for a "quick fix" to get the templated UI working, but not great for
-// longer term maintainability.
-//func buildHtmlData(pullRequests contributed.MergedPullRequestInfo) []pageData {
-//
-//	var pd []pageData
-//
-//	for owner, prInfo := range pullRequests {
-//
-//		data := pageData{
-//			Owner:     owner,
-//			AvatarURL: prInfo.AvatarURL,
-//			Repos:     []Repository{},
-//		}
-//
-//		for k, v := range prInfo.PullRequests {
-//
-//			r := Repository{
-//				Name:         k,
-//				PullRequests: []PullReq{},
-//			}
-//
-//			for title, url := range v {
-//				req := PullReq{
-//					Title: title,
-//					URL:   url,
-//				}
-//				r.PullRequests = append(r.PullRequests, req)
-//			}
-//
-//			data.Repos = append(data.Repos, r)
-//		}
-//
-//		pd = append(pd, data)
-//
-//	}
-//
-//	return pd
-//
-//}
-
 func printContributions(co []contributed.Contribution) {
 	for _, c := range co {
-		log.Printf("%+v\n", c)
+		log.Printf("%+v\n", c.Owner)
 	}
 }
+
 
 func main() {
 	flag.IntVar(&cacheSize, "cache-size", 1000, "number of items available to cache")

--- a/cmd/contributord/contributord.go
+++ b/cmd/contributord/contributord.go
@@ -23,7 +23,6 @@ var (
 	uiServeFile string
 )
 
-
 func main() {
 	flag.IntVar(&cacheSize, "cache-size", 1000, "number of items available to cache")
 	flag.StringVar(&addr, "address", "localhost", "address to bind")

--- a/pkg/contributed/contributed.go
+++ b/pkg/contributed/contributed.go
@@ -88,7 +88,6 @@ type Contribution struct {
 	AvatarURL string
 	Repos     []Repository
 }
-type PullRequests map[string]map[string]string
 
 // FetchMergedPullRequestsByUser will fetch the merged pull requests for a given
 // user from the GitHub API, it initially uses a nil cursor that is then populated

--- a/pkg/contributed/contributed.go
+++ b/pkg/contributed/contributed.go
@@ -43,25 +43,24 @@ var (
 	port      string
 )
 
-// MergedPullRequestInfo contains the relevant information which is fetched from
-// the GraphQL query, this is returned to the user.
-type MergedPullRequestInfo map[string]PullRequestInfo
-
-// PullRequestInfo represents information about a pull request to a repository
-// owner mapping. This holds the avatar URL and merged pull requests together.
-type PullRequestInfo struct {
-
-	// AvatarURL is the display picture of the repository owner or organisation.
-	AvatarURL string `json:"avatarURL"`
-
-	// PullRequests is the internal representation for the map structure of a
-	// owner/organisation to multiple merged pull requests.
-	PullRequests PullRequests `json:"pullRequests"`
+// PullRequest defines a GitHub pull request.
+type PullRequest struct {
+	Title string
+	URL   string
 }
 
-// PullRequests is a custom wrapper around the structure of the response, this
-// is a mapping of the repository owner/organisation to the repositories that
-// they own, with the merged pull requests contained within the mapping.
+// Repository is a GitHub repository. For this project,
+// contributed-to is the repository.
+type Repository struct {
+	Name         string
+	PullRequests []PullRequest
+}
+
+// Contribution is a merged pull request to a specific repository, or repositories, owned
+// by a GitHub user, that the desired author has contributed to.
+//
+// When utilised with the cache of GitHub user name it is a mapping of the specified user to their
+// successful contributions to other organisation's or repository owners project's.
 //
 // For example:
 //


### PR DESCRIPTION
The initial choice of using multiple `map[string]map[string]MergedPullRequestInfo` was relatively poor.

It made it really simple to iterate through the model and pull out a user and the contributions, but having this actually displayed and accessed anywhere else outside of simple `range` loops was quite difficult. I.e. for the UI, I cannot simply refer to the items that are `string` keys within the map, as their value is not known - compared to a `struct` where is it `{{ .StructFieldName }}` for it to be displayed.