### PR TITLE
chore: better errors

### DIFF
--- a/cmd/contributed/contributed.go
+++ b/cmd/contributed/contributed.go
@@ -47,6 +47,10 @@ func getUser(user string, refreshCache bool) ([]contributed.Contribution, error)
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusInternalServerError {
+		return nil, fmt.Errorf("unable to load contributions for %s\n", user)
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The CLI would render an error from `json.Unmarshal` as it would proceed to attempt to unmarshal the `500, {error: "..."}` into a `[]Contribtuion` struct slice - this is now not the case and it properly prints an error to state that the contribution data cannot be retrieved.

On top of this, I've also added in a new `error.html` page so that when a user cannot be found, we show a simple error message by rendering a new page. It is a little hacky in that we pass in the `fake` anonymous `struct` in order to get the message, but I think this is okay for now.

As a short drive-by change, I also fixed the missing `return` on an error. Without this being present, it caused the page to be rendered twice because the `c.HTML` call was made consequtively on an error, causing 2 pages to be shown.
